### PR TITLE
Update dependencies and drop sonars

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ module.exports = {
     "@typescript-eslint",
     "promise",
     "unicorn",
-    "sonarjs",
     "react",
     "react-hooks",
     "prettier",
@@ -32,7 +31,6 @@ module.exports = {
     "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",
     "plugin:unicorn/recommended",
-    "plugin:sonarjs/recommended",
     "prettier/@typescript-eslint",
     "plugin:prettier/recommended",
     "prettier/react",
@@ -399,17 +397,6 @@ module.exports = {
     "unicorn/no-null": "off",
     "unicorn/no-reduce": "off",
     "unicorn/no-fn-reference-in-iterator": "off",
-
-    // Sonar
-    "sonarjs/no-small-switch": "warn",
-    "sonarjs/prefer-immediate-return": "off",
-    "sonarjs/cognitive-complexity": "warn",
-    "sonarjs/no-identical-expressions": "warn",
-    "sonarjs/no-unused-collection": "warn",
-    "sonarjs/no-identical-functions": "warn",
-    "sonarjs/no-collapsible-if": "warn",
-    "sonarjs/no-duplicated-branches": "warn",
-    "sonarjs/no-redundant-boolean": "warn",
 
     // react
     "react/jsx-filename-extension": ["warn", { extensions: [".js", ".tsx"] }],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-react-config-r13v",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "main": "index.js",
   "scripts": {},
   "author": "Rustam Gilyaziev <gilaziev@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -15,27 +15,26 @@
   "homepage": "https://github.com/r13v/eslint-config-react-r13v#readme",
   "description": "",
   "devDependencies": {
-    "eslint": "^7.14.0"
+    "eslint": "^7.18.0"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.8.2",
-    "@typescript-eslint/parser": "^4.8.2",
-    "eslint-config-prettier": "^6.15.0",
+    "@typescript-eslint/eslint-plugin": "^4.14.1",
+    "@typescript-eslint/parser": "^4.14.1",
+    "eslint-config-prettier": "^7.2.0",
     "eslint-import-resolver-typescript": "^2.3.0",
-    "eslint-plugin-formatjs": "^2.9.10",
+    "eslint-plugin-formatjs": "^2.10.6",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.1.3",
-    "eslint-plugin-jsdoc": "^30.7.8",
-    "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-jsdoc": "^31.3.3",
+    "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-react": "^7.21.5",
+    "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "eslint-plugin-sonarjs": "^0.5.0",
-    "eslint-plugin-unicorn": "^23.0.0",
+    "eslint-plugin-unicorn": "^27.0.0",
     "prettier": "^2.2.1",
-    "typescript": "^4.1.2"
+    "typescript": "^4.1.3"
   },
   "peerDependencies": {
-    "eslint": ">=7.14.0"
+    "eslint": ">=7.18.0"
   }
 }


### PR DESCRIPTION
Drop sonar js since it does not support eslint 7. Has not updated since the 2019 year and PR is open a few months